### PR TITLE
Migrate vmm_callout -> OSX libdispatch

### DIFF
--- a/include/xhyve/vmm/vmm_callout.h
+++ b/include/xhyve/vmm/vmm_callout.h
@@ -93,7 +93,6 @@ struct callout {
 #define C_ABSOLUTE 0x0200 /* event time is absolute */
 #define CALLOUT_ACTIVE 0x0002 /* callout is currently active */
 #define CALLOUT_PENDING 0x0004 /* callout is waiting for timeout */
-#define CALLOUT_MPSAFE 0x0008 /* callout handler is mp safe */
 #define CALLOUT_RETURNUNLOCKED 0x0010 /* handler returns with mtx unlocked */
 #define CALLOUT_COMPLETED 0x0020 /* callout thread finished */
 #define CALLOUT_WAITING 0x0040 /* thread waiting for callout to finish */

--- a/include/xhyve/vmm/vmm_callout.h
+++ b/include/xhyve/vmm/vmm_callout.h
@@ -70,6 +70,7 @@ static inline void bintime_sub(struct bintime *_bt, const struct bintime *_bt2)
     ((a)->frac cmp (b)->frac) : \
     ((a)->sec cmp (b)->sec))
 
+extern int tc_precexp;
 
 void binuptime(struct bintime *bt);
 void getmicrotime(struct timeval *tv);
@@ -84,6 +85,7 @@ static inline sbintime_t sbinuptime(void) {
 struct callout {
   dispatch_source_t timer;
   uint64_t timeout;
+  uint64_t precision;
   void *argument;
   void (*callout)(void *);
   int flags;

--- a/include/xhyve/vmm/vmm_callout.h
+++ b/include/xhyve/vmm/vmm_callout.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include <stdint.h>
-#include <pthread.h>
 #include <time.h>
 #include <sys/time.h>
+#include <dispatch/dispatch.h>
 
 #define SBT_1S  ((sbintime_t)1 << 32)
 #define SBT_1M  (SBT_1S * 60)
@@ -82,9 +82,7 @@ static inline sbintime_t sbinuptime(void) {
 }
 
 struct callout {
-  pthread_cond_t wait;
-  struct callout *prev;
-  struct callout *next;
+  dispatch_source_t timer;
   uint64_t timeout;
   void *argument;
   void (*callout)(void *);

--- a/include/xhyve/vmm/vmm_callout.h
+++ b/include/xhyve/vmm/vmm_callout.h
@@ -83,6 +83,7 @@ static inline sbintime_t sbinuptime(void) {
 }
 
 struct callout {
+  dispatch_group_t group;
   dispatch_source_t timer;
   uint64_t timeout;
   uint64_t precision;

--- a/src/vmm/io/vatpit.c
+++ b/src/vmm/io/vatpit.c
@@ -155,11 +155,12 @@ static void
 pit_timer_start_cntr0(struct vatpit *vatpit)
 {
 	struct channel *c;
-	sbintime_t now, delta;
+	sbintime_t now, delta, precision;
 
 	c = &vatpit->channel[0];
 	if (c->initial != 0) {
 		delta = c->initial * vatpit->freq_sbt;
+		precision = delta >> tc_precexp;
 		c->callout_sbt = c->callout_sbt + delta;
 
 		/*
@@ -172,7 +173,7 @@ pit_timer_start_cntr0(struct vatpit *vatpit)
 			c->callout_sbt = now + delta;
 
 		callout_reset_sbt(&c->callout, c->callout_sbt,
-		    0, vatpit_callout_handler, &c->callout_arg,
+		    precision, vatpit_callout_handler, &c->callout_arg,
 		    C_ABSOLUTE);
 	}
 }

--- a/src/vmm/io/vatpit.c
+++ b/src/vmm/io/vatpit.c
@@ -429,7 +429,7 @@ vatpit_init(struct vm *vm)
 	vatpit->freq_sbt = bttosbt(bt);
 
 	for (i = 0; i < 3; i++) {
-		callout_init(&vatpit->channel[i].callout, true);
+		callout_init(&vatpit->channel[i].callout, 1);
 		arg = &vatpit->channel[i].callout_arg;
 		arg->vatpit = vatpit;
 		arg->channel_num = i;

--- a/src/vmm/io/vhpet.c
+++ b/src/vmm/io/vhpet.c
@@ -325,7 +325,7 @@ vhpet_stop_timer(struct vhpet *vhpet, int n, sbintime_t now)
 static void
 vhpet_start_timer(struct vhpet *vhpet, int n, uint32_t counter, sbintime_t now)
 {
-	sbintime_t delta;
+	sbintime_t delta, precision;
 
 	if (vhpet->timer[n].comprate != 0)
 		vhpet_adjust_compval(vhpet, n, counter);
@@ -339,9 +339,10 @@ vhpet_start_timer(struct vhpet *vhpet, int n, uint32_t counter, sbintime_t now)
 	}
 
 	delta = (vhpet->timer[n].compval - counter) * vhpet->freq_sbt;
+	precision = delta >> tc_precexp;
 	vhpet->timer[n].callout_sbt = now + delta;
 	callout_reset_sbt(&vhpet->timer[n].callout, vhpet->timer[n].callout_sbt,
-	    0, vhpet_handler, &vhpet->timer[n].arg, C_ABSOLUTE);
+	    precision, vhpet_handler, &vhpet->timer[n].arg, C_ABSOLUTE);
 }
 
 static void

--- a/src/vmm/vmm_callout.c
+++ b/src/vmm/vmm_callout.c
@@ -22,32 +22,23 @@
  * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
- *
  */
-
-/* makeshift callout implementation based on OSv and FreeBSD */
 
 #include <stdio.h>
 #include <stdint.h>
 #include <stdbool.h>
 #include <stdlib.h>
 #include <errno.h>
-#include <pthread.h>
 #include <sys/time.h>
 #include <mach/mach.h>
 #include <mach/mach_time.h>
+#include <dispatch/dispatch.h>
 
 #include <xhyve/support/misc.h>
 #include <xhyve/vmm/vmm_callout.h>
 
-#define callout_cmp(a, b) ((a)->timeout < (b)->timeout)
-
 static mach_timebase_info_data_t timebase_info;
-static pthread_t callout_thread;
-static pthread_mutex_t callout_mtx;
-static pthread_cond_t callout_cnd;
-static struct callout *callout_queue;
-static bool work;
+static dispatch_queue_t queue;
 static bool initialized = false;
 
 static inline uint64_t nanos_to_abs(uint64_t nanos) {
@@ -65,15 +56,6 @@ static inline uint64_t sbt2mat(sbintime_t sbt) {
   ns = (((uint64_t) 1000000000) * (uint32_t) sbt) >> 32;
   
   return (nanos_to_abs((s * 1000000000) + ns));
-}
-
-static inline void mat_to_ts(uint64_t mat, struct timespec *ts) {
-  uint64_t ns;
-  
-  ns = abs_to_nanos(mat);
-  
-  ts->tv_sec = (ns / 1000000000);
-  ts->tv_nsec = (ns % 1000000000);
 }
 
 void binuptime(struct bintime *bt) {
@@ -95,133 +77,36 @@ void getmicrotime(struct timeval *tv) {
   tv->tv_usec = (int) ((ns - sns) / 1000);
 }
 
-static void callout_insert(struct callout *c) {
-  struct callout *node = callout_queue;
+static void dispatcher(void* data) {
+  struct callout *c = (struct callout *) data;
 
-  if (!node) {
-    callout_queue = c;
-    c->prev = NULL;
-    c->next = NULL;
-    c->queued = 1;
-    return;
-  }
-  
-  if (callout_cmp(c, node)) {
-    node->prev = c;
-    c->prev = NULL;
-    c->next = node;
-    callout_queue = c;
-    c->queued = 1;
-    return;
-  }
-  
-  while (node->next) {
-    if (callout_cmp(c, node->next)) {
-      c->prev = node;
-      c->next = node->next;
-      node->next->prev = c;
-      node->next = c;
-      c->queued = 1;
-      return;
-    }
-    node = node->next;
-  }
-  
-  c->prev = node;
-  c->next = NULL;
-  node->next = c;
-  c->queued = 1;
-}
-
-static void callout_remove(struct callout *c) {
-  if (!c->queued) {
-    return;
+  if (!(c->flags & (CALLOUT_ACTIVE | CALLOUT_PENDING))) {
+    abort();
   }
 
-  if (c->prev) {
-    c->prev->next = c->next;
-  } else {
-    callout_queue = c->next;
-  }
-  
-  if (c->next) {
-    c->next->prev = c->prev;
-  }
-  
-  c->prev = NULL;
-  c->next = NULL;
-  c->queued = 0;
-}
+  /* dispatch */
+  c->flags &= ~CALLOUT_PENDING;
 
-static void *callout_thread_func(UNUSED void *arg) {
-  struct callout *c;
-  struct timespec ts;
-  uint64_t delta, mat;
-  int ret;
+  c->callout(c->argument);
 
-  pthread_mutex_lock(&callout_mtx);
+  /* note: after the handler has been invoked the callout structure can look
+   *       much differently, the handler may have rescheduled the callout or
+   *       even freed it.
+   *
+   *       if the callout is still enqueued it means that it hasn't been
+   *       freed by the user
+   *
+   *       reset || drain || !stop
+   */
 
-  while (true) {
-    /* wait for work */
-    while (!callout_queue) {
-      pthread_cond_wait(&callout_cnd, &callout_mtx);
-    };
-
-    /* get the callout with the nearest timout */
-    c = callout_queue;
-
-    if (!(c->flags & (CALLOUT_ACTIVE | CALLOUT_PENDING))) {
-      abort();
-    }
-
-    /* wait for timeout */
-    ret = 0;
-    while ((ret != ETIMEDOUT) && !work) {
-      mat = mach_absolute_time();
-      if (mat >= c->timeout) {
-        /* XXX: it might not be worth sleeping for very short timeouts */
-        ret = ETIMEDOUT;
-        break;
-      }
-
-      delta = c->timeout - mat;
-      mat_to_ts(delta, &ts);
-      ret = pthread_cond_timedwait_relative_np(&callout_cnd, &callout_mtx, &ts);
-    };
-
-    work = false;
-
-    if (!(ret == ETIMEDOUT) || !c->queued) {
-      continue;
-    }
-
-    /* dispatch */
-    c->flags &= ~CALLOUT_PENDING;
-
-    pthread_mutex_unlock(&callout_mtx);
-    c->callout(c->argument);
-    pthread_mutex_lock(&callout_mtx);
-    
-    /* note: after the handler has been invoked the callout structure can look
-     *       much differently, the handler may have rescheduled the callout or
-     *       even freed it.
-     *
-     *       if the callout is still enqueued it means that it hasn't been
-     *       freed by the user
-     *
-     *       reset || drain || !stop
-     */
-
-    if (c->queued) {
-      /* if the callout hasn't been rescheduled, remove it */
-      if (((c->flags & CALLOUT_PENDING) == 0) || (c->flags & CALLOUT_WAITING)) {
-        c->flags |= CALLOUT_COMPLETED;
-        callout_remove(c);
-      }
+  if (c->queued) {
+    /* if the callout hasn't been rescheduled, remove it */
+    if (((c->flags & CALLOUT_PENDING) == 0) || (c->flags & CALLOUT_WAITING)) {
+      c->flags |= CALLOUT_COMPLETED;
+      dispatch_suspend(c->timer);
+      c->queued = 0;
     }
   }
-
-  return NULL;
 }
 
 void callout_init(struct callout *c, int mpsafe) {
@@ -231,94 +116,72 @@ void callout_init(struct callout *c, int mpsafe) {
 
   memset(c, 0, sizeof(struct callout));
 
-  if (pthread_cond_init(&c->wait, NULL)) {
-    abort();
-  }
+  c->timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, queue);
+  dispatch_set_context(c->timer, c);
+  dispatch_source_set_event_handler_f(c->timer, dispatcher);
 }
 
-static int callout_stop_safe_locked(struct callout *c, int drain) {
+int callout_stop_safe(struct callout *c, int drain) {
   int result = 0;
-  
-  if ((drain) && (pthread_self() != callout_thread) && (callout_pending(c) ||
-    (callout_active(c) && !callout_completed(c))))
+
+  if ((drain) && (callout_pending(c) || (callout_active(c) && !callout_completed(c))))
   {
     if (c->flags & CALLOUT_WAITING) {
       abort();
     }
-    
+
     /* wait for callout */
     c->flags |= CALLOUT_WAITING;
-    work = true;
 
-    pthread_cond_signal(&callout_cnd);
-  
-    while (!(c->flags & CALLOUT_COMPLETED)) {
-      pthread_cond_wait(&c->wait, &callout_mtx);
+    while (!callout_completed(c)) {
+      // FIXME
+      //pthread_cond_wait(&c->wait, NULL);
     }
 
     c->flags &= ~CALLOUT_WAITING;
     result = 1;
   }
-  
-  callout_remove(c);
-  
-  /* clear flags */
-  c->flags &= ~(CALLOUT_ACTIVE | CALLOUT_PENDING | CALLOUT_COMPLETED |
-    CALLOUT_WAITING);
-  
-  return (result);
-}
 
-int callout_stop_safe(struct callout *c, int drain) {
-  pthread_mutex_lock(&callout_mtx);
-  callout_stop_safe_locked(c, drain);
-  pthread_mutex_unlock(&callout_mtx);
-  return 0;
+  if (c->queued) {
+    dispatch_suspend(c->timer);
+    c->queued = 0;
+  }
+
+  /* clear flags */
+  c->flags &= ~(CALLOUT_ACTIVE | CALLOUT_PENDING | CALLOUT_COMPLETED | CALLOUT_WAITING);
+
+  return result;
 }
 
 int callout_reset_sbt(struct callout *c, sbintime_t sbt,
   UNUSED sbintime_t precision, void (*ftn)(void *), void *arg, int flags)
 {
   int result;
-  bool is_next_timeout;
-  
-  is_next_timeout = false;
 
-  pthread_mutex_lock(&callout_mtx);
-  
   if (!((flags == 0) || (flags == C_ABSOLUTE)) || (c->flags !=0)) {
     /* FIXME */
     //printf("XHYVE: callout_reset_sbt 0x%08x 0x%08x\r\n", flags, c->flags);
     //abort();
   }
 
-  c->timeout = sbt2mat(sbt);
-  
-  if (flags != C_ABSOLUTE) {
-    c->timeout += mach_absolute_time();
+  c->timeout = abs_to_nanos(sbt2mat(sbt));
+
+  if (flags == C_ABSOLUTE) {
+    c->timeout -= abs_to_nanos(mach_absolute_time());
   }
 
-  result = callout_stop_safe_locked(c, 0);
-  
+  result = callout_stop_safe(c, 0);
+
   c->callout = ftn;
   c->argument = arg;
   c->flags |= (CALLOUT_PENDING | CALLOUT_ACTIVE);
-  
-  callout_insert(c);
-  
-  if (c == callout_queue) {
-    work = true;
-    is_next_timeout = true;
-  }
-  
-  pthread_mutex_unlock(&callout_mtx);
-  
-  if (is_next_timeout) {
-    pthread_cond_signal(&callout_cnd);
-    is_next_timeout = false;
-  }
-  
-  return (result);
+
+  dispatch_time_t start = dispatch_time(DISPATCH_TIME_NOW, (int64_t) c->timeout);
+  dispatch_source_set_timer(c->timer, start, DISPATCH_TIME_FOREVER, 0);
+  dispatch_resume(c->timer);
+  c->queued = 1;
+
+  return result;
 }
 
 void callout_system_init(void) {
@@ -327,53 +190,8 @@ void callout_system_init(void) {
   }
 
   mach_timebase_info(&timebase_info);
-  
-  if (pthread_mutex_init(&callout_mtx, NULL)) {
-    abort();
-  }
-  
-  if (pthread_cond_init(&callout_cnd, NULL)) {
-    abort();
-  }
-  
-  callout_queue = NULL;
-  work = false;
-  
-  if (pthread_create(&callout_thread, /*&attr*/ NULL, &callout_thread_func,
-    NULL))
-  {
-    abort();
-  }
+
+  queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
   
   initialized = true;
 }
-
-//static void callout_queue_print(void) {
-//  struct callout *node;
-//  
-//  pthread_mutex_lock(&callout_mtx);
-//  for (node = callout_queue; node; node = node->next) {
-//    printf("t:%llu -> ", abs_to_nanos(node->timeout));
-//    if (!node->next) {
-//      break;
-//    }
-//  }
-//  pthread_mutex_unlock(&callout_mtx);
-//  printf("NULL\n");
-//}
-
-//void fire (void *arg) {
-//  printf("fire!\n");
-//}
-//
-//int main(void) {
-//  struct callout a;
-//  sbintime_t sbt;
-//  printf("xhyve_timer\n");
-//  callout_system_init();
-//  callout_init(&a, 1);
-//  sbt = ((sbintime_t) (((uint64_t) 3) << 32));
-//  callout_reset_sbt(&a, sbt, 0, &fire, NULL, 0);
-//  while (1);
-//  return 0;
-//}

--- a/src/vmm/vmm_callout.c
+++ b/src/vmm/vmm_callout.c
@@ -124,8 +124,7 @@ void callout_init(struct callout *c, int mpsafe) {
 int callout_stop_safe(struct callout *c, int drain) {
   int result = 0;
 
-  if ((drain) && (callout_pending(c) || (callout_active(c) && !callout_completed(c))))
-  {
+  if ((drain) && (callout_pending(c) || (callout_active(c) && !callout_completed(c)))) {
     if (c->flags & CALLOUT_WAITING) {
       abort();
     }
@@ -154,21 +153,22 @@ int callout_stop_safe(struct callout *c, int drain) {
 }
 
 int callout_reset_sbt(struct callout *c, sbintime_t sbt,
-  UNUSED sbintime_t precision, void (*ftn)(void *), void *arg, int flags)
-{
+  UNUSED sbintime_t precision, void (*ftn)(void *), void *arg, int flags) {
   int result;
 
-  if (!((flags == 0) || (flags == C_ABSOLUTE)) || (c->flags !=0)) {
+  if (!((flags == 0) || (flags == C_ABSOLUTE)) || (c->flags != 0)) {
     /* FIXME */
     //printf("XHYVE: callout_reset_sbt 0x%08x 0x%08x\r\n", flags, c->flags);
     //abort();
   }
 
-  c->timeout = abs_to_nanos(sbt2mat(sbt));
+  c->timeout = sbt2mat(sbt);
 
   if (flags == C_ABSOLUTE) {
-    c->timeout -= abs_to_nanos(mach_absolute_time());
+    c->timeout -= mach_absolute_time();
   }
+
+  c->timeout = abs_to_nanos(c->timeout);
 
   result = callout_stop_safe(c, 0);
 
@@ -191,7 +191,7 @@ void callout_system_init(void) {
 
   mach_timebase_info(&timebase_info);
 
-  queue = dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0);
-  
+  queue = dispatch_queue_create(NULL, DISPATCH_QUEUE_SERIAL);
+
   initialized = true;
 }

--- a/src/vmm/vmm_callout.c
+++ b/src/vmm/vmm_callout.c
@@ -94,8 +94,6 @@ static void dispatcher(void* data) {
 
   c->callout(c->argument);
 
-  dispatch_group_leave(c->group);
-
   /* note: after the handler has been invoked the callout structure can look
    *       much differently, the handler may have rescheduled the callout or
    *       even freed it.
@@ -114,6 +112,8 @@ static void dispatcher(void* data) {
       c->flags |= CALLOUT_COMPLETED;
     }
   }
+
+  dispatch_group_leave(c->group);
 }
 
 void callout_init(struct callout *c, int mpsafe) {


### PR DESCRIPTION
Tries to be a cleaner implementation then the current one, based upon what I saw in README.md - TODO I thought it was a good idea to migrate it. I wouldn't say it is complete, but it could be a good starting point. I haven't seen any issues by running a VM for a couple of hours with multiple sleeps with this patch.
