### PR TITLE
Document how to determine a compatible CPU

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Requirements
 ------------
 
 * OS X 10.10.3 Yosemite or later
-* a 2010 or later Mac (i.e. a CPU that supports EPT)
+* a 2010 or later Mac (i.e. a CPU that supports EPT: `sysctl kern.hv_support` = 1)
 
 Installation
 ------------


### PR DESCRIPTION
It currently takes some digging to check your CPU compatibility.  A one liner makes it easy.  To determine if your cpu is compatible, run `sysctl kern.hv_support` at the command line.  If the result is 1, you are xhyve ready.