### PR TITLE
Fix MacOSX 10.15 CC_MD5 deprecation errors

### DIFF
--- a/src/pci_ahci.c
+++ b/src/pci_ahci.c
@@ -2278,7 +2278,7 @@ pci_ahci_init(struct pci_devinst *pi, char *opts, int atapi)
 	struct blockif_ctxt *bctxt;
 	struct pci_ahci_softc *sc;
 	int ret, slots;
-	u_char digest[16];
+	u_char digest[CC_SHA256_DIGEST_LENGTH];
 
 	ret = 0;
 
@@ -2319,7 +2319,7 @@ pci_ahci_init(struct pci_devinst *pi, char *opts, int atapi)
 	 * Create an identifier for the backing file. Use parts of the
 	 * md5 sum of the filename
 	 */
-    CC_MD5(opts, (CC_LONG)strlen(opts), digest);
+    CC_SHA256(opts, (CC_LONG)strlen(opts), digest);
     snprintf(sc->port[0].ident, AHCI_PORT_IDENT, "BHYVE-%02X%02X-%02X%02X-%02X%02X",
 	    digest[0], digest[1], digest[2], digest[3], digest[4], digest[5]);
 

--- a/src/pci_virtio_block.c
+++ b/src/pci_virtio_block.c
@@ -313,7 +313,7 @@ pci_vtblk_init(struct pci_devinst *pi, char *opts)
 {
 	char bident[sizeof("XX:X:X")];
 	struct blockif_ctxt *bctxt;
-	u_char digest[16];
+	u_char digest[CC_SHA256_DIGEST_LENGTH];
 	struct pci_vtblk_softc *sc;
 	off_t size;
 	int i, sectsz, sts, sto;
@@ -360,7 +360,7 @@ pci_vtblk_init(struct pci_devinst *pi, char *opts)
 	 * Create an identifier for the backing file. Use parts of the
 	 * md5 sum of the filename
 	 */
-    CC_MD5(opts, (CC_LONG)strlen(opts), digest);
+    CC_SHA256(opts, (CC_LONG)strlen(opts), digest);
 	snprintf(sc->vbsc_ident, VTBLK_BLK_ID_BYTES, "BHYVE-%02X%02X-%02X%02X-%02X%02X",
 	    digest[0], digest[1], digest[2], digest[3], digest[4], digest[5]);
 

--- a/src/pci_virtio_net_tap.c
+++ b/src/pci_virtio_net_tap.c
@@ -572,7 +572,7 @@ pci_vtnet_parsemac(char *mac_str, uint8_t *mac_addr)
 static int
 pci_vtnet_init(struct pci_devinst *pi, char *opts)
 {
-	unsigned char digest[16];
+	unsigned char digest[CC_SHA256_DIGEST_LENGTH];
 	char nstr[80];
 	struct pci_vtnet_softc *sc;
 	char *devname;
@@ -669,7 +669,7 @@ pci_vtnet_init(struct pci_devinst *pi, char *opts)
 		snprintf(nstr, sizeof(nstr), "%d-%d-%s", pi->pi_slot,
 		    pi->pi_func, vmname);
 
-        CC_MD5(nstr, (CC_LONG)strlen(nstr), digest);
+        CC_SHA256(nstr, (CC_LONG)strlen(nstr), digest);
 
 		sc->vsc_config.mac[0] = 0x00;
 		sc->vsc_config.mac[1] = 0xa0;

--- a/src/smbiostbl.c
+++ b/src/smbiostbl.c
@@ -598,8 +598,8 @@ smbios_type1_initializer(struct smbios_structure *template_entry,
 
 		uuid_enc_le(&type1->uuid, &uuid);
 	} else {
-		CC_MD5_CTX	mdctx;
-		u_char		digest[16];
+		CC_SHA256_CTX	mdctx;
+		u_char		digest[CC_SHA256_DIGEST_LENGTH];
 		char		hostname[MAXHOSTNAMELEN];
 
 		/*
@@ -610,10 +610,10 @@ smbios_type1_initializer(struct smbios_structure *template_entry,
 		if (gethostname(hostname, sizeof(hostname)))
 			return (-1);
 
-		CC_MD5_Init(&mdctx);
-		CC_MD5_Update(&mdctx, vmname, ((unsigned) strlen(vmname)));
-		CC_MD5_Update(&mdctx, hostname, ((unsigned) sizeof(hostname)));
-		CC_MD5_Final(digest, &mdctx);
+		CC_SHA256_Init(&mdctx);
+		CC_SHA256_Update(&mdctx, vmname, ((unsigned) strlen(vmname)));
+		CC_SHA256_Update(&mdctx, hostname, ((unsigned) sizeof(hostname)));
+		CC_SHA256_Final(digest, &mdctx);
 
 		/*
 		 * Set the variant and version number.


### PR DESCRIPTION
Use CC_SHA1 instead.
