### PR TITLE
Fix PCI device ID for virtio-rnd (from bhyve)

### DIFF
--- a/include/xhyve/virtio.h
+++ b/include/xhyve/virtio.h
@@ -216,7 +216,7 @@ struct vring_used {
 #define	VIRTIO_VENDOR		0x1AF4
 #define	VIRTIO_DEV_NET		0x1000
 #define	VIRTIO_DEV_BLOCK	0x1001
-#define	VIRTIO_DEV_RANDOM	0x1002
+#define	VIRTIO_DEV_RANDOM	0x1005
 
 /*
  * PCI config space constants.


### PR DESCRIPTION
FreeBSD bhyve commit: https://svnweb.freebsd.org/base?view=revision&revision=311702
From that commit message:
> This prevented the device from attaching with a Windows guest (most other guests use the device type for matching).

The corrected ID also matches the [PCI ID Repository](https://pci-ids.ucw.cz/read/PC/1af4).

I haven't tested Windows, but Linux and OpenBSD guests do load the driver correctly, albeit with the PCI device identified incorrectly as the memory ballooning device.  I'm using `-s 5,virtio-rnd` for these VMs.

Before - Linux **lspci:**
```
00:05.0 Network and computing encryption device: Red Hat, Inc. Virtio memory balloon
```
Before - OpenBSD **dmesg** and **pcidump:**
```
virtio1 at pci0 dev 5 function 0 "Qumranet Virtio Memory Balloon" rev 0x00
viornd0 at virtio1
# pcidump
 0:5:0: Qumranet Virtio Memory Balloon
```

With the fix, everything is correctly identified and virtio-rnd still works (at least my Linux VM gets new random data each time I run `dd if=/dev/hwrng count=1 | hexdump -C`).

After:
```
# Linux lspci
00:05.0 Network and computing encryption device: Red Hat, Inc. Virtio RNG
# OpenBSD dmesg
virtio1 at pci0 dev 5 function 0 "Qumranet Virtio RNG" rev 0x00
viornd0 at virtio1
# OpenBSD pcidump
 0:5:0: Qumranet Virtio RNG
```