### PR TITLE
Add com.apple.security.hypervisor to entitlements

### DIFF
--- a/src/xhyve-entitlements.plist
+++ b/src/xhyve-entitlements.plist
@@ -6,6 +6,8 @@
     <true/>
     <key>com.apple.security.network.server</key>
     <true/>
+    <key>com.apple.security.hypervisor</key>
+    <true/>
     <key>com.apple.vm.networking</key>
     <true/>
     <key>com.apple.vm.hypervisor</key>


### PR DESCRIPTION
`com.apple.security.hypervisor` is a new entitlement to replace `com.apple.vm.hypervisor`. Keeping both so that it remains compatible with macOS 10.15 or earlier.

See: https://developer.apple.com/documentation/bundleresources/entitlements/com_apple_security_hypervisor