### PR TITLE
don't care about Don't Care bits

### DIFF
--- a/include/xhyve/vmm/intel/vmx.h
+++ b/include/xhyve/vmm/intel/vmx.h
@@ -46,6 +46,7 @@ struct vmxstate {
 	uint64_t nextrip;	/* next instruction to be executed by guest */
 	int	lastcpu;	/* host cpu that this 'vcpu' last ran on */
 	uint16_t vpid;
+    uint32_t entry_ctls;
 };
 #pragma clang diagnostic pop
 

--- a/include/xhyve/vmm/intel/vmx_msr.h
+++ b/include/xhyve/vmm/intel/vmx_msr.h
@@ -41,5 +41,5 @@ void vmx_msr_guest_init(struct vmx *vmx, int vcpuid);
 int vmx_rdmsr(struct vmx *, int vcpuid, u_int num, uint64_t *val);
 int vmx_wrmsr(struct vmx *, int vcpuid, u_int num, uint64_t val);
 
-int vmx_set_ctlreg(hv_vmx_capability_t cap_field, uint32_t ones_mask,
+int vmx_set_ctlreg(int vcpu_id, uint32_t field, hv_vmx_capability_t cap_field, uint32_t ones_mask,
 				   uint32_t zeros_mask, uint32_t *retval);

--- a/xhyve.xcodeproj/project.pbxproj
+++ b/xhyve.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 				3F1934931BF7C0D40099CC46 /* Products */,
 			);
 			sourceTree = "<group>";
+			usesTabs = 1;
 		};
 		3F1934931BF7C0D40099CC46 /* Products */ = {
 			isa = PBXGroup;


### PR DESCRIPTION
The previous code cared about Don't Care bits in capability fields for controls by terminating with an error when encountering any unknown ones. This causes problems on newer CPUs, which adds new such bits for new features. It is safe and recommended to simply retain the current value in the respective control for such bits, and this change does that. Some rearchitecting was needed, because the previous code treated the capabilities as global.