### PR TITLE
Explicitly cast to uint8_t

### DIFF
--- a/src/pci_ahci.c
+++ b/src/pci_ahci.c
@@ -220,8 +220,8 @@ static inline void lba_to_msf(uint8_t *buf, int lba)
 {
 	lba += 150;
 	buf[0] = (uint8_t) ((lba / 75) / 60);
-	buf[1] = (lba / 75) % 60;
-	buf[2] = lba % 75;
+	buf[1] = (uint8_t) (lba / 75) % 60;
+	buf[2] = (uint8_t) (lba % 75);
 }
 
 /*

--- a/src/vmm/vmm_instruction_emul.c
+++ b/src/vmm/vmm_instruction_emul.c
@@ -1467,7 +1467,7 @@ emulate_bittest(void *vm, int vcpuid, uint64_t gpa, struct vie *vie,
 	 * "Range of Bit Positions Specified by Bit Offset Operands"
 	 */
 	bitmask = vie->opsize * 8 - 1;
-	bitoff = vie->immediate & bitmask;
+	bitoff = (uint8_t)(vie->immediate & bitmask);
 
 	/* Copy the bit into the Carry flag in %rflags */
 	if (val & (1UL << bitoff))


### PR DESCRIPTION
Apple clang-1300.0.29.3 (ships with macOS 11.6) requires to use `-Wno-shorten-64-to-32` and `-Wsnoign-conversion`, or explicitly cast to smaller type or signed type.

`immediate` is `int64_t` and `opsize` is 4 bits field which makes mask clearly no more than 5 bits => cast to `uint8_t` is safe here and just makes clang happy and code clean.

`buf[]` is also `uint8_t` and cast happened before but implicitly.