### PR TITLE
Managed HV_DENIED as a possible return value from hv_vm_create

### DIFF
--- a/src/vmm/intel/vmx.c
+++ b/src/vmm/intel/vmx.c
@@ -483,6 +483,11 @@ vmx_init(void)
 		case HV_NO_RESOURCES:
 			/* Don't know if this can happen, report to us */
 			xhyve_abort("hv_vm_create HV_NO_RESOURCES\n");
+#if __MAC_OS_X_VERSION_MIN_REQUIRED >= 111000
+		case HV_DENIED:
+			/* This does happen on Big Sur, can't tell the reason */
+			xhyve_abort("hv_vm_create HV_DENIED\n");
+#endif
 		case HV_NO_DEVICE:
 			printf("vmx_init: processor not supported by "
 			       "Hypervisor.framework\n");
@@ -492,7 +497,7 @@ vmx_init(void)
 			xhyve_abort("hv_vm_create HV_UNSUPPORTED\n");
 		default:
 			/* Should never happen, report to Apple */
-			xhyve_abort("hv_vm_create unknown error %d\n", error);
+			xhyve_abort("hv_vm_create unknown error %x\n", error);
 	}
 
 	/*


### PR DESCRIPTION
I discovered this additional return value while debugging some problems with using xhyve locally.
It is available at least since MacOSX SDK version 11.1.